### PR TITLE
feat: add testMain and cleanUp testcontainers

### DIFF
--- a/internal/repositories/pet/create_test.go
+++ b/internal/repositories/pet/create_test.go
@@ -2,19 +2,24 @@ package pet_test
 
 import (
 	"poc-testcontainers/internal/models"
+	"poc-testcontainers/internal/repositories/pet"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateRepository(t *testing.T) {
-	cleanUpPetDB(t)
+	tx := db.Begin()
+	repo := pet.NewPetRepository(tx)
+
+	defer tx.Rollback()
+
 	t.Run("Should create pet correctly", func(t *testing.T) {
 		user := models.User{
 			Name: "test-name",
 			Age:  20,
 		}
-		db.Create(&user)
+		tx.Create(&user)
 
 		p := models.Pet{
 			Name:             "test-pet-name",
@@ -24,7 +29,7 @@ func TestCreateRepository(t *testing.T) {
 		result, err := repo.Create(&p)
 
 		var petCreated models.Pet
-		db.Where("name", "test-pet-name").First(&petCreated)
+		tx.Where("name", "test-pet-name").First(&petCreated)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)

--- a/internal/repositories/pet/create_test.go
+++ b/internal/repositories/pet/create_test.go
@@ -1,30 +1,20 @@
 package pet_test
 
 import (
-	"context"
 	"poc-testcontainers/internal/models"
-	"poc-testcontainers/internal/repositories/pet"
-	"poc-testcontainers/internal/repositories/testutils"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateRepository(t *testing.T) {
-	ctx := context.Background()
-	db, err := testutils.NewTestDatabase(ctx, &models.Pet{})
-	if err != nil {
-		t.Fatalf("Error getting test db \nReason= %s", err.Error())
-	}
-
-	gormDB := db.GormDB
-	repo := pet.NewPetRepository(gormDB)
+	cleanUpPetDB(t)
 	t.Run("Should create pet correctly", func(t *testing.T) {
 		user := models.User{
 			Name: "test-name",
 			Age:  20,
 		}
-		gormDB.Create(&user)
+		db.Create(&user)
 
 		p := models.Pet{
 			Name:             "test-pet-name",
@@ -34,7 +24,7 @@ func TestCreateRepository(t *testing.T) {
 		result, err := repo.Create(&p)
 
 		var petCreated models.Pet
-		gormDB.Where("name", "test-pet-name").First(&petCreated)
+		db.Where("name", "test-pet-name").First(&petCreated)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)

--- a/internal/repositories/pet/list_test.go
+++ b/internal/repositories/pet/list_test.go
@@ -1,24 +1,14 @@
 package pet_test
 
 import (
-	"context"
 	"poc-testcontainers/internal/models"
-	"poc-testcontainers/internal/repositories/pet"
-	"poc-testcontainers/internal/repositories/testutils"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestListRepository(t *testing.T) {
-	ctx := context.Background()
-	db, err := testutils.NewTestDatabase(ctx, &models.Pet{})
-	if err != nil {
-		t.Fatalf("Error getting test db \nReason= %s", err.Error())
-	}
-
-	gormDB := db.GormDB
-	repo := pet.NewPetRepository(gormDB)
+	cleanUpPetDB(t)
 	t.Run("Should list pet filtered correctly", func(t *testing.T) {
 		users := []models.User{
 			{
@@ -32,7 +22,7 @@ func TestListRepository(t *testing.T) {
 				Age:  30,
 			},
 		}
-		gormDB.Create(&users)
+		db.Create(&users)
 
 		pets := []models.Pet{
 			{
@@ -56,7 +46,7 @@ func TestListRepository(t *testing.T) {
 				UserRespnsibleID: users[0].ID,
 			},
 		}
-		gormDB.Create(&pets)
+		db.Create(&pets)
 
 		filter := models.Pet{
 			UserRespnsibleID: users[0].ID,

--- a/internal/repositories/pet/list_test.go
+++ b/internal/repositories/pet/list_test.go
@@ -2,13 +2,18 @@ package pet_test
 
 import (
 	"poc-testcontainers/internal/models"
+	"poc-testcontainers/internal/repositories/pet"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestListRepository(t *testing.T) {
-	cleanUpPetDB(t)
+	tx := db.Begin()
+	repo := pet.NewPetRepository(tx)
+
+	defer tx.Rollback()
+
 	t.Run("Should list pet filtered correctly", func(t *testing.T) {
 		users := []models.User{
 			{
@@ -22,7 +27,7 @@ func TestListRepository(t *testing.T) {
 				Age:  30,
 			},
 		}
-		db.Create(&users)
+		tx.Create(&users)
 
 		pets := []models.Pet{
 			{
@@ -46,7 +51,7 @@ func TestListRepository(t *testing.T) {
 				UserRespnsibleID: users[0].ID,
 			},
 		}
-		db.Create(&pets)
+		tx.Create(&pets)
 
 		filter := models.Pet{
 			UserRespnsibleID: users[0].ID,

--- a/internal/repositories/pet/pet_test.go
+++ b/internal/repositories/pet/pet_test.go
@@ -1,0 +1,42 @@
+package pet_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"poc-testcontainers/internal/application"
+	"poc-testcontainers/internal/models"
+	"poc-testcontainers/internal/repositories/pet"
+	"poc-testcontainers/internal/repositories/testutils"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+var db *gorm.DB
+var repo application.PetRepository
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	testDB, err := testutils.NewTestDatabase(ctx, &models.Pet{})
+	if err != nil {
+		fmt.Printf("Error getting test db \nReason= %s", err.Error())
+		os.Exit(1)
+	}
+	gormDB := testDB.GormDB
+	repo = pet.NewPetRepository(gormDB)
+	db = gormDB
+
+	m.Run()
+
+	if err := testDB.Cleanup(ctx); err != nil {
+		fmt.Printf("failed to clean up test database: %v\n", err)
+	}
+}
+
+func cleanUpPetDB(t *testing.T) {
+	t.Helper()
+
+	db.Raw("DELETE FROM users")
+	db.Raw("DELETE FROM pet")
+}

--- a/internal/repositories/pet/pet_test.go
+++ b/internal/repositories/pet/pet_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"poc-testcontainers/internal/application"
 	"poc-testcontainers/internal/models"
-	"poc-testcontainers/internal/repositories/pet"
 	"poc-testcontainers/internal/repositories/testutils"
 	"testing"
 
@@ -14,29 +12,19 @@ import (
 )
 
 var db *gorm.DB
-var repo application.PetRepository
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
-	testDB, err := testutils.NewTestDatabase(ctx, &models.Pet{})
+	testDB, err := testutils.NewTestDatabase(ctx, &models.User{}, &models.Pet{})
 	if err != nil {
 		fmt.Printf("Error getting test db \nReason= %s", err.Error())
 		os.Exit(1)
 	}
-	gormDB := testDB.GormDB
-	repo = pet.NewPetRepository(gormDB)
-	db = gormDB
+	db = testDB.GormDB
 
 	m.Run()
 
 	if err := testDB.Cleanup(ctx); err != nil {
 		fmt.Printf("failed to clean up test database: %v\n", err)
 	}
-}
-
-func cleanUpPetDB(t *testing.T) {
-	t.Helper()
-
-	db.Raw("DELETE FROM users")
-	db.Raw("DELETE FROM pet")
 }

--- a/internal/repositories/user/create_test.go
+++ b/internal/repositories/user/create_test.go
@@ -1,24 +1,14 @@
 package user_test
 
 import (
-	"context"
 	"poc-testcontainers/internal/models"
-	"poc-testcontainers/internal/repositories/testutils"
-	"poc-testcontainers/internal/repositories/user"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateRepository(t *testing.T) {
-	ctx := context.Background()
-	db, err := testutils.NewTestDatabase(ctx, &models.User{})
-	if err != nil {
-		t.Fatalf("Error getting test db \nReason= %s", err.Error())
-	}
-
-	gormDB := db.GormDB
-	repo := user.NewUserRepository(gormDB)
+	cleanUpUserDB(t)
 	t.Run("Should create user correctly", func(t *testing.T) {
 		u := models.User{
 			Name: "test-name",
@@ -27,7 +17,7 @@ func TestCreateRepository(t *testing.T) {
 		result, err := repo.Create(&u)
 
 		var userCreated models.User
-		gormDB.Where("name", "test-name").First(&userCreated)
+		db.Where("name", "test-name").First(&userCreated)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)

--- a/internal/repositories/user/create_test.go
+++ b/internal/repositories/user/create_test.go
@@ -2,13 +2,18 @@ package user_test
 
 import (
 	"poc-testcontainers/internal/models"
+	"poc-testcontainers/internal/repositories/user"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateRepository(t *testing.T) {
-	cleanUpUserDB(t)
+	tx := db.Begin()
+	repo := user.NewUserRepository(tx)
+
+	defer tx.Rollback()
+
 	t.Run("Should create user correctly", func(t *testing.T) {
 		u := models.User{
 			Name: "test-name",
@@ -17,7 +22,7 @@ func TestCreateRepository(t *testing.T) {
 		result, err := repo.Create(&u)
 
 		var userCreated models.User
-		db.Where("name", "test-name").First(&userCreated)
+		tx.Where("name", "test-name").First(&userCreated)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)

--- a/internal/repositories/user/delete_test.go
+++ b/internal/repositories/user/delete_test.go
@@ -1,25 +1,14 @@
 package user_test
 
 import (
-	"context"
 	"poc-testcontainers/internal/models"
-	"poc-testcontainers/internal/repositories/testutils"
-	"poc-testcontainers/internal/repositories/user"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDeletetRepository(t *testing.T) {
-	ctx := context.Background()
-	db, err := testutils.NewTestDatabase(ctx, &models.User{})
-	if err != nil {
-		t.Fatalf("Error getting test db \nReason= %s", err.Error())
-	}
-
-	gormDB := db.GormDB
-	repo := user.NewUserRepository(gormDB)
-	gormDB.Raw("DELETE FROM users")
+	cleanUpUserDB(t)
 	t.Run("Should delete user correctly", func(t *testing.T) {
 		users := []models.User{
 			{
@@ -43,12 +32,12 @@ func TestDeletetRepository(t *testing.T) {
 				Age:  40,
 			},
 		}
-		gormDB.Create(&users)
+		db.Create(&users)
 
 		err := repo.Delete(users[1].ID)
 
 		var result []models.User
-		gormDB.Find(&result)
+		db.Find(&result)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)

--- a/internal/repositories/user/delete_test.go
+++ b/internal/repositories/user/delete_test.go
@@ -2,13 +2,18 @@ package user_test
 
 import (
 	"poc-testcontainers/internal/models"
+	"poc-testcontainers/internal/repositories/user"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDeletetRepository(t *testing.T) {
-	cleanUpUserDB(t)
+	tx := db.Begin()
+	repo := user.NewUserRepository(tx)
+
+	defer tx.Rollback()
+
 	t.Run("Should delete user correctly", func(t *testing.T) {
 		users := []models.User{
 			{
@@ -32,12 +37,12 @@ func TestDeletetRepository(t *testing.T) {
 				Age:  40,
 			},
 		}
-		db.Create(&users)
+		tx.Create(&users)
 
 		err := repo.Delete(users[1].ID)
 
 		var result []models.User
-		db.Find(&result)
+		tx.Find(&result)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)

--- a/internal/repositories/user/list_test.go
+++ b/internal/repositories/user/list_test.go
@@ -2,13 +2,18 @@ package user_test
 
 import (
 	"poc-testcontainers/internal/models"
+	"poc-testcontainers/internal/repositories/user"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestListRepository(t *testing.T) {
-	cleanUpUserDB(t)
+	tx := db.Begin()
+	repo := user.NewUserRepository(tx)
+
+	defer tx.Rollback()
+
 	t.Run("Should list users filtered correctly", func(t *testing.T) {
 		users := []models.User{
 			{
@@ -32,7 +37,7 @@ func TestListRepository(t *testing.T) {
 				Age:  40,
 			},
 		}
-		db.Create(&users)
+		tx.Create(&users)
 		filter := models.User{
 			Age: 30,
 		}
@@ -41,7 +46,7 @@ func TestListRepository(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
-		assert.Equal(t, 3, len(result))
+		assert.Equal(t, 2, len(result))
 		assert.Equal(t, result[0].Name, "test-name-2")
 		assert.Equal(t, result[1].Name, "test-name-3")
 	})

--- a/internal/repositories/user/list_test.go
+++ b/internal/repositories/user/list_test.go
@@ -1,24 +1,14 @@
 package user_test
 
 import (
-	"context"
 	"poc-testcontainers/internal/models"
-	"poc-testcontainers/internal/repositories/testutils"
-	"poc-testcontainers/internal/repositories/user"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestListRepository(t *testing.T) {
-	ctx := context.Background()
-	db, err := testutils.NewTestDatabase(ctx, &models.User{})
-	if err != nil {
-		t.Fatalf("Error getting test db \nReason= %s", err.Error())
-	}
-
-	gormDB := db.GormDB
-	repo := user.NewUserRepository(gormDB)
+	cleanUpUserDB(t)
 	t.Run("Should list users filtered correctly", func(t *testing.T) {
 		users := []models.User{
 			{
@@ -42,7 +32,7 @@ func TestListRepository(t *testing.T) {
 				Age:  40,
 			},
 		}
-		gormDB.Create(&users)
+		db.Create(&users)
 		filter := models.User{
 			Age: 30,
 		}

--- a/internal/repositories/user/list_test.go
+++ b/internal/repositories/user/list_test.go
@@ -41,7 +41,7 @@ func TestListRepository(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
-		assert.Equal(t, 2, len(result))
+		assert.Equal(t, 3, len(result))
 		assert.Equal(t, result[0].Name, "test-name-2")
 		assert.Equal(t, result[1].Name, "test-name-3")
 	})

--- a/internal/repositories/user/user_test.go
+++ b/internal/repositories/user/user_test.go
@@ -1,0 +1,41 @@
+package user_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"poc-testcontainers/internal/application"
+	"poc-testcontainers/internal/models"
+	"poc-testcontainers/internal/repositories/testutils"
+	"poc-testcontainers/internal/repositories/user"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+var db *gorm.DB
+var repo application.UserRepository
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	testDB, err := testutils.NewTestDatabase(ctx, &models.User{})
+	if err != nil {
+		fmt.Printf("Error getting test db \nReason= %s", err.Error())
+		os.Exit(1)
+	}
+	gormDB := testDB.GormDB
+	repo = user.NewUserRepository(gormDB)
+	db = gormDB
+
+	m.Run()
+
+	if err := testDB.Cleanup(ctx); err != nil {
+		fmt.Printf("failed to clean up test database: %v\n", err)
+	}
+}
+
+func cleanUpUserDB(t *testing.T) {
+	t.Helper()
+
+	db.Raw("DELETE FROM users")
+}

--- a/internal/repositories/user/user_test.go
+++ b/internal/repositories/user/user_test.go
@@ -4,17 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"poc-testcontainers/internal/application"
 	"poc-testcontainers/internal/models"
 	"poc-testcontainers/internal/repositories/testutils"
-	"poc-testcontainers/internal/repositories/user"
 	"testing"
 
 	"gorm.io/gorm"
 )
 
 var db *gorm.DB
-var repo application.UserRepository
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
@@ -23,19 +20,11 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Error getting test db \nReason= %s", err.Error())
 		os.Exit(1)
 	}
-	gormDB := testDB.GormDB
-	repo = user.NewUserRepository(gormDB)
-	db = gormDB
+	db = testDB.GormDB
 
 	m.Run()
 
 	if err := testDB.Cleanup(ctx); err != nil {
 		fmt.Printf("failed to clean up test database: %v\n", err)
 	}
-}
-
-func cleanUpUserDB(t *testing.T) {
-	t.Helper()
-
-	db.Raw("DELETE FROM users")
 }


### PR DESCRIPTION
- Add a TestMain to setup testcontainers db once per package (There is no need to run tests iniside package in parallel)
- Terminate testcontainers after all tests
- Add transaction usage on tests to maitain db clean